### PR TITLE
fixed a crash when the map is rotated more than 90 degrees

### DIFF
--- a/MSMapClustering/MSMapClusteringDelegate.m
+++ b/MSMapClustering/MSMapClusteringDelegate.m
@@ -114,7 +114,7 @@ static float bucketSize = 60.0;
   // Determine how wide each bucket will be, as a MapRect square
   CLLocationCoordinate2D leftCoordinate = [self.mapView convertPoint:CGPointZero toCoordinateFromView:[self.mapView superview]];
   CLLocationCoordinate2D rightCoordinate = [self.mapView convertPoint:CGPointMake(bucketSize, 0) toCoordinateFromView:[self.mapView superview]];
-  double gridSize = MKMapPointForCoordinate(rightCoordinate).x - MKMapPointForCoordinate(leftCoordinate).x;
+  double gridSize = fabs(MKMapPointForCoordinate(rightCoordinate).x - MKMapPointForCoordinate(leftCoordinate).x);
   MKMapRect gridMapRect = MKMapRectMake(0, 0, gridSize, gridSize);
 
   // Condense annotations with a padding of two squares, around the visibleMapRect


### PR DESCRIPTION
When `-updateVisibleAnnotations` is called with a map that has been rotated more than 90 degrees, `gridSize` is negative, causing an infinite loop. This leads to a large number of memory allocations which eventually ends in an out-of-memory crash.
